### PR TITLE
Update login_process API for 3.1.9

### DIFF
--- a/app/api/account.php
+++ b/app/api/account.php
@@ -86,7 +86,7 @@ class account extends AWS_CONTROLLER
 				//}
 
 				$this->model('account')->update_user_last_login($user_info['uid']);
-				$this->model('account')->setcookie_logout();
+				$this->model('account')->logout();
 
 				$this->model('account')->setcookie_login($user_info['uid'], $_POST['user_name'], $_POST['password'], $user_info['salt'], $expire);
 


### PR DESCRIPTION
在WeCenter 3.1.9版本中，setcookie_logout改成了logout
https://github.com/wecenter/wecenter/blob/master/models/account.php#L791